### PR TITLE
Support py_zipkin v0.7.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     py_modules=['sqlalchemy_zipkin'],
     platforms='any',
     install_requires=[
-        'py_zipkin>=0.4.0',
+        'py_zipkin>=0.7.0',
         'SQLAlchemy>=0.9.8',
     ],
 )

--- a/sqlalchemy_zipkin.py
+++ b/sqlalchemy_zipkin.py
@@ -127,7 +127,7 @@ class SqlAlchemyZipkinInstrumentation(object):
             parameters = ()
 
         # Add SQLAlchemy attributes to span before stopping it. Noop is sampling is not set or 0
-        span.update_binary_annotations_for_root_span({
+        span.update_binary_annotations({
             'sql.engine.id': id(conn.engine),
             'sql.engine.url': str(url),
             'sql.statement': statement[:self.max_length],


### PR DESCRIPTION
The function update_binary_annotations_for_root_span has been replaced in v0.7.0

Other than that the instrumentor is working properly with v0.20.0